### PR TITLE
Add "declare" keyword

### DIFF
--- a/drools-mode.el
+++ b/drools-mode.el
@@ -40,7 +40,7 @@ possibly preceded by whitespace."
   "Drools commands and operators occuring within actions.")
 
 (defvar drools-toplevel-keywords 
-  '("rule" "end" "package" "import" "function" "global" "expander")
+  '("rule" "end" "package" "import" "function" "global" "expander" "declare")
   "Drools keywords that occur at top-level in source file, and should always be indented to 0")
 
 (defvar drools-section-keywords '("when" "then")
@@ -58,7 +58,7 @@ possibly preceded by whitespace."
   (regexp-for-keyword-at-start-of-line (append drools-section-keywords)) 
   "Regexp to match a line starting with a Drools section keyword" )
 
-(defvar drools-indenting-keyword-regexp (regexp-for-keywords '("rule" "when" "then"))
+(defvar drools-indenting-keyword-regexp (regexp-for-keywords '("rule" "when" "then" "declare"))
   "Regexp for Drools keywords which cause indent on following lines.")
 
 (defvar drools-tab-indent 4 "Default indentation for Drools mode")


### PR DESCRIPTION
"declare" keyword allows to create new type in drools syntax ([drools documentation](https://docs.jboss.org/drools/release/6.5.0.Final/drools-docs/html/ch08.html#d0e8240)).
Example:

declare Address
   number : int
   streetName : String
   city : String
end

